### PR TITLE
feat: p1-docs

### DIFF
--- a/Components/Card/card.css
+++ b/Components/Card/card.css
@@ -129,14 +129,14 @@
 }
 
 .card-button {
-  height: 2.5rem;
-  padding: 0rem 2rem;
-  padding-top: 0.4rem;
+  padding: 1rem 1rem;
   display: flex;
   align-content: center;
   justify-content: center;
-  width: 12rem;
-  font-weight: 500;
+  width: fit-content;
+  font-weight: 700;
+  font: inherit;
+  font-size: small;
 }
 
 .card-shadow {

--- a/Components/Card/card.html
+++ b/Components/Card/card.html
@@ -588,9 +588,6 @@
           </div>
         </div>
       </div>
-
-      <h2>All Cards Completed</h2>
-      <!-- sdfs -->
     </div>
   </body>
 </html>

--- a/Docs/Alert/alert.html
+++ b/Docs/Alert/alert.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/Avatar/avatar.html
+++ b/Docs/Avatar/avatar.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/Badge/badge.html
+++ b/Docs/Badge/badge.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/Button/button.html
+++ b/Docs/Button/button.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/Card/card.html
+++ b/Docs/Card/card.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/Grid/grid.html
+++ b/Docs/Grid/grid.html
@@ -5,38 +5,191 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Grid</title>
-    <link rel="stylesheet" href="../default.css" />
-    <link rel="stylesheet" href="grid.css" />
+    <link rel="icon" href="../../hero-icon.svg" />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h1>Grid Examples</h1>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent z-index-2"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
+        </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
 
-      <h2>2 items in grid</h2>
-      <div class="grid-2 black-border">
-        <div class="bright-blue-bg white-color grid-item-1 grid-item-example">
-          Item 1
-        </div>
-        <div class="bright-green-bg white-color grid-item-2 grid-item-example">
-          Item 2
-        </div>
-      </div>
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
 
-      <h2>3 items in grid</h2>
-      <div class="grid-3 black-border">
-        <div class="bright-blue-bg white-color grid-item-1 grid-item-example-2">
-          Item 1
+        <li class="navigation-link-item component-list-button">
+          <button
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
+          >
+            <div class="material-icons-outlined">menu</div>
+          </button>
+        </li>
+      </ul>
+    </nav>
+
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
+
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
+            </li>
+          </a>
+
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>Grid</h1>
+        <p>
+          A simplified grid can be used to quickly arrange items in a grid
+          container.
+        </p>
+
+        <h2>2 items in grid</h2>
+        <div class="grid-2 black-border">
+          <div class="bright-blue-bg white-color grid-item-1 grid-item-example">
+            Item 1
+          </div>
+          <div
+            class="bright-green-bg white-color grid-item-2 grid-item-example"
+          >
+            Item 2
+          </div>
         </div>
-        <div
-          class="bright-green-bg white-color grid-item-2 grid-item-example-2"
-        >
-          Item 2
+
+        <h2>3 items in grid</h2>
+        <div class="grid-3 black-border">
+          <div
+            class="bright-blue-bg white-color grid-item-1 grid-item-example-2"
+          >
+            Item 1
+          </div>
+          <div
+            class="bright-green-bg white-color grid-item-2 grid-item-example-2"
+          >
+            Item 2
+          </div>
+          <div
+            class="bright-yellow-bg white-color grid-item-3 grid-item-example-2"
+          >
+            Item 3
+          </div>
         </div>
-        <div
-          class="bright-yellow-bg white-color grid-item-3 grid-item-example-2"
-        >
-          Item 3
-        </div>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FGrid%2Fgrid.html%23L12-L41&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/Docs/Image/image.html
+++ b/Docs/Image/image.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/Input/input.html
+++ b/Docs/Input/input.html
@@ -102,7 +102,7 @@
             </li>
           </a>
 
-          <a href="../Input/input.html">
+          <a href="../Text-Utilities/text.html">
             <li class="component-list-item list-item black-bg white-color">
               Text Utilities
             </li>

--- a/Docs/List/list.html
+++ b/Docs/List/list.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lists</title>
+    <link rel="icon" href="../../hero-icon.svg" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
@@ -12,66 +14,205 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="../default.css" />
-    <link rel="stylesheet" href="list.css" />
-    <title>List</title>
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h3>Normal List</h3>
-      <ul class="default-list">
-        <li class="list-item">Pencil</li>
-        <li class="list-item">Pen</li>
-        <li class="list-item">Eraser</li>
-        <li class="list-item">Compass</li>
-        <li class="list-item">Scale</li>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent z-index-2"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
+        </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
+
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
+
+        <li class="navigation-link-item component-list-button">
+          <button
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
+          >
+            <div class="material-icons-outlined">menu</div>
+          </button>
+        </li>
       </ul>
+    </nav>
 
-      <h3>Stacked List</h3>
-      <div class="notification-container notification-shadow">
-        <div class="notification-title-container">
-          <div class="material-icons-outlined">shopping_cart</div>
-          <div class="notification-title">Order shipped</div>
-          <div class="material-icons-outlined notification-close-icon">
-            cancel
-          </div>
-        </div>
-        <div class="notification-text-container">
-          <div class="notification-text">
-            Your order has been shipped. Arriving in 5 day(s)
-          </div>
-        </div>
-      </div>
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
 
-      <div class="notification-container notification-shadow">
-        <div class="notification-title-container">
-          <div class="material-icons-outlined">notifications</div>
-          <div class="notification-title">Order delivered</div>
-          <div class="material-icons-outlined notification-close-icon">
-            cancel
-          </div>
-        </div>
-        <div class="notification-text-container">
-          <div class="notification-text">
-            Your order for Super Thinking and 2 other items has been delivered.
-          </div>
-        </div>
-      </div>
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
+            </li>
+          </a>
 
-      <div class="notification-container notification-shadow">
-        <div class="notification-title-container">
-          <div class="material-icons-outlined">timer</div>
-          <div class="notification-title">Time is running out</div>
-          <div class="material-icons-outlined notification-close-icon">
-            cancel
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>List</h1>
+        <p>List is ordered or unordered collection of related items.</p>
+
+        <h3>Normal List</h3>
+        <ul class="default-list">
+          <li class="list-item">Pencil</li>
+          <li class="list-item">Pen</li>
+          <li class="list-item">Eraser</li>
+          <li class="list-item">Compass</li>
+          <li class="list-item">Scale</li>
+        </ul>
+
+        <h3>Stacked List</h3>
+        <div class="notification-container notification-shadow">
+          <div class="notification-title-container">
+            <div class="material-icons-outlined">shopping_cart</div>
+            <div class="notification-title">Order shipped</div>
+            <div class="material-icons-outlined notification-close-icon">
+              cancel
+            </div>
+          </div>
+          <div class="notification-text-container">
+            <div class="notification-text">
+              Your order has been shipped. Arriving in 5 day(s)
+            </div>
           </div>
         </div>
-        <div class="notification-text-container">
-          <div class="notification-text">
-            Last 2 hours of 5th Aniversary sale. Huge discounts on your
-            favourite titles. Order now !!
+
+        <div class="notification-container notification-shadow">
+          <div class="notification-title-container">
+            <div class="material-icons-outlined">notifications</div>
+            <div class="notification-title">Order delivered</div>
+            <div class="material-icons-outlined notification-close-icon">
+              cancel
+            </div>
+          </div>
+          <div class="notification-text-container">
+            <div class="notification-text">
+              Your order for Super Thinking and 2 other items has been
+              delivered.
+            </div>
           </div>
         </div>
+
+        <div class="notification-container notification-shadow">
+          <div class="notification-title-container">
+            <div class="material-icons-outlined">timer</div>
+            <div class="notification-title">Time is running out</div>
+            <div class="material-icons-outlined notification-close-icon">
+              cancel
+            </div>
+          </div>
+          <div class="notification-text-container">
+            <div class="notification-text">
+              Last 2 hours of 5th Aniversary sale. Huge discounts on your
+              favourite titles. Order now !!
+            </div>
+          </div>
+        </div>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FList%2Flist.html%23L20-L76&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/Docs/Modal/modal.html
+++ b/Docs/Modal/modal.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Modal</title>
+    <link rel="icon" href="../../hero-icon.svg" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
@@ -13,58 +14,197 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="../default.css" />
-    <link rel="stylesheet" href="modal.css" />
-    <link rel="stylesheet" href="../Button/button.css" />
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h3>Modal</h3>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent z-index-2"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
+        </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
 
-      <div class="modal red-bg modal-shadow">
-        <div class="modal-title-bar">
-          <div class="modal-title">Are you sure ?</div>
-          <div class="material-icons-outlined md-36">cancel</div>
-        </div>
-        <div class="modal-text-container">
-          This action can't be undone, be sure to check all the details. Don't
-          press back or refresh button while your data is being saved.
-        </div>
-        <div class="modal-action-container">
-          <button
-            class="button card-button pillbox-button white-color black-bg"
-          >
-            Yes
-          </button>
-          <button
-            class="button card-button pillbox-button white-color bright-red-bg"
-          >
-            No
-          </button>
-        </div>
-      </div>
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
 
-      <div class="modal green-bg modal-shadow">
-        <div class="modal-title-bar">
-          <div class="modal-title">Data saved</div>
-          <div class="material-icons-outlined md-36">cancel</div>
-        </div>
-        <div class="modal-text-container">
-          Your data has been saved, you can safely close this window or exit
-          this tab. This message will automatically be closed in 5 second(s).
-        </div>
-        <div class="display-none">
+        <li class="navigation-link-item component-list-button">
           <button
-            class="button card-button pillbox-button white-color black-bg"
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
           >
-            Yes
+            <div class="material-icons-outlined">menu</div>
           </button>
-          <button
-            class="button card-button pillbox-button white-color bright-red-bg"
-          >
-            No
-          </button>
+        </li>
+      </ul>
+    </nav>
+
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
+
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
+            </li>
+          </a>
+
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>Modal</h1>
+        <p>
+          A modal can serve as a pop-up to alert and make user about significant
+          application state changes.
+        </p>
+
+        <div class="modal red-bg modal-shadow">
+          <div class="modal-title-bar">
+            <div class="modal-title">Are you sure ?</div>
+            <div class="material-icons-outlined md-36">cancel</div>
+          </div>
+          <div class="modal-text-container">
+            This action can't be undone, be sure to check all the details. Don't
+            press back or refresh button while your data is being saved.
+          </div>
+          <div class="modal-action-container">
+            <button
+              class="button card-button pillbox-button white-color black-bg"
+            >
+              Yes
+            </button>
+            <button
+              class="button card-button pillbox-button white-color bright-red-bg"
+            >
+              No
+            </button>
+          </div>
         </div>
+
+        <div class="modal green-bg modal-shadow">
+          <div class="modal-title-bar">
+            <div class="modal-title">Data saved</div>
+            <div class="material-icons-outlined md-36">cancel</div>
+          </div>
+          <div class="modal-text-container">
+            Your data has been saved, you can safely close this window or exit
+            this tab. This message will automatically be closed in 5 second(s).
+          </div>
+          <div class="display-none">
+            <button
+              class="button card-button pillbox-button white-color black-bg"
+            >
+              Yes
+            </button>
+            <button
+              class="button card-button pillbox-button white-color bright-red-bg"
+            >
+              No
+            </button>
+          </div>
+        </div>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FModal%2Fmodal.html%23L21-L69&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/Docs/Modal/modal.html
+++ b/Docs/Modal/modal.html
@@ -149,8 +149,8 @@
       <div class="column-container component-details-container">
         <h1>Modal</h1>
         <p>
-          A modal can serve as a pop-up to alert and make user about significant
-          application state changes.
+          A modal can serve as a pop-up to alert and make user aware before
+          significant application state changes.
         </p>
 
         <div class="modal red-bg modal-shadow">

--- a/Docs/Navigation/navigation.html
+++ b/Docs/Navigation/navigation.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Navbar</title>
+    <title>Navigation</title>
+    <link rel="icon" href="../../hero-icon.svg" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
@@ -13,110 +14,251 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="../default.css" />
-    <link rel="stylesheet" href="navigation.css" />
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h3>Normal Navigation Bar</h3>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent z-index-2"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
+        </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
 
-      <div class="navigation-container">
-        <nav class="navigation bright-blue-bg white-color">
-          <div class="navigation-title-container">
-            <div class="material-icons-outlined">widgets</div>
-            <h1>App</h1>
-          </div>
-          <ul class="navigation-links-container">
-            <li class="navigation-link-item">
-              <a href="https://www.google.com" target="_blank"> Home </a>
-            </li>
-            <li class="navigation-link-item">
-              <a href="https://www.google.com" target="_blank"> Saved </a>
-            </li>
-            <li class="navigation-link-item">
-              <a href="https://www.google.com" target="_blank"> Log Out </a>
-            </li>
-          </ul>
-        </nav>
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
 
-        <p>
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industry's standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
-        </p>
-        <p>
-          It was popularised in the 1960s with the release of Letraset sheets
-          containing Lorem Ipsum passages, and more recently with desktop
-          publishing software like Aldus PageMaker including versions of Lorem
-          Ipsum.
-        </p>
-        <p>
-          It is a long established fact that a reader will be distracted by the
-          readable content of a page when looking at its layout. The point of
-          using Lorem Ipsum is that it has a more-or-less normal distribution of
-          letters, as opposed to using 'Content here, content here', making it
-          look like readable English.
-        </p>
-        <p>
-          Many desktop publishing packages and web page editors now use Lorem
-          Ipsum as their default model text, and a search for 'lorem ipsum' will
-          uncover many web sites still in their infancy. Various versions have
-          evolved over the years, sometimes by accident, sometimes on purpose
-          (injected humour and the like).
-        </p>
-      </div>
+        <li class="navigation-link-item component-list-button">
+          <button
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
+          >
+            <div class="material-icons-outlined">menu</div>
+          </button>
+        </li>
+      </ul>
+    </nav>
 
-      <h3>Fixed Navigation Bar</h3>
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
 
-      <div class="navigation-container">
-        <nav class="navigation bright-purple-bg white-color fixed-navigation">
-          <div class="navigation-title-container">
-            <div class="material-icons-outlined">widgets</div>
-            <h1>App</h1>
-          </div>
-          <ul class="navigation-links-container">
-            <li class="navigation-link-item">
-              <a href="https://www.google.com" target="_blank"> Home </a>
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
             </li>
-            <li class="navigation-link-item">
-              <a href="https://www.google.com" target="_blank"> Saved </a>
-            </li>
-            <li class="navigation-link-item">
-              <a href="https://www.google.com" target="_blank"> Log Out </a>
-            </li>
-          </ul>
-        </nav>
+          </a>
 
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>Navigation</h1>
         <p>
-          <br />
-          <br />
-          <br />
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been the industry's standard dummy text ever
-          since the 1500s, when an unknown printer took a galley of type and
-          scrambled it to make a type specimen book.
+          A navigation bar acts a common set of actions across different screens
+          of an application.
         </p>
-        <p>
-          It was popularised in the 1960s with the release of Letraset sheets
-          containing Lorem Ipsum passages, and more recently with desktop
-          publishing software like Aldus PageMaker including versions of Lorem
-          Ipsum.
-        </p>
-        <p>
-          It is a long established fact that a reader will be distracted by the
-          readable content of a page when looking at its layout. The point of
-          using Lorem Ipsum is that it has a more-or-less normal distribution of
-          letters, as opposed to using 'Content here, content here', making it
-          look like readable English.
-        </p>
-        <p>
-          Many desktop publishing packages and web page editors now use Lorem
-          Ipsum as their default model text, and a search for 'lorem ipsum' will
-          uncover many web sites still in their infancy. Various versions have
-          evolved over the years, sometimes by accident, sometimes on purpose
-          (injected humour and the like).
-        </p>
+
+        <h3>Normal Navigation Bar</h3>
+
+        <div class="navigation-container">
+          <nav class="navigation bright-blue-bg white-color">
+            <div class="navigation-title-container">
+              <div class="material-icons-outlined">widgets</div>
+              <h1>App</h1>
+            </div>
+            <ul class="navigation-links-container">
+              <li class="navigation-link-item">
+                <a href="https://www.google.com" target="_blank"> Home </a>
+              </li>
+              <li class="navigation-link-item">
+                <a href="https://www.google.com" target="_blank"> Saved </a>
+              </li>
+              <li class="navigation-link-item">
+                <a href="https://www.google.com" target="_blank"> Log Out </a>
+              </li>
+            </ul>
+          </nav>
+
+          <p>
+            Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. Lorem Ipsum has been the industry's standard dummy text
+            ever since the 1500s, when an unknown printer took a galley of type
+            and scrambled it to make a type specimen book.
+          </p>
+          <p>
+            It was popularised in the 1960s with the release of Letraset sheets
+            containing Lorem Ipsum passages, and more recently with desktop
+            publishing software like Aldus PageMaker including versions of Lorem
+            Ipsum.
+          </p>
+          <p>
+            It is a long established fact that a reader will be distracted by
+            the readable content of a page when looking at its layout. The point
+            of using Lorem Ipsum is that it has a more-or-less normal
+            distribution of letters, as opposed to using 'Content here, content
+            here', making it look like readable English.
+          </p>
+          <p>
+            Many desktop publishing packages and web page editors now use Lorem
+            Ipsum as their default model text, and a search for 'lorem ipsum'
+            will uncover many web sites still in their infancy. Various versions
+            have evolved over the years, sometimes by accident, sometimes on
+            purpose (injected humour and the like).
+          </p>
+        </div>
+
+        <h3>Fixed Navigation Bar</h3>
+
+        <div class="navigation-container">
+          <nav
+            class="navigation bright-purple-bg white-color fixed-navigation-component absolute-position"
+          >
+            <div class="navigation-title-container">
+              <div class="material-icons-outlined">widgets</div>
+              <h1>App</h1>
+            </div>
+            <ul class="navigation-links-container">
+              <li class="navigation-link-item">
+                <a href="https://www.google.com" target="_blank"> Home </a>
+              </li>
+              <li class="navigation-link-item">
+                <a href="https://www.google.com" target="_blank"> Saved </a>
+              </li>
+              <li class="navigation-link-item">
+                <a href="https://www.google.com" target="_blank"> Log Out </a>
+              </li>
+            </ul>
+          </nav>
+
+          <p class="fixed-navigation-text-padding">
+            Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. Lorem Ipsum has been the industry's standard dummy text
+            ever since the 1500s, when an unknown printer took a galley of type
+            and scrambled it to make a type specimen book.
+          </p>
+          <p>
+            It was popularised in the 1960s with the release of Letraset sheets
+            containing Lorem Ipsum passages, and more recently with desktop
+            publishing software like Aldus PageMaker including versions of Lorem
+            Ipsum.
+          </p>
+          <p>
+            It is a long established fact that a reader will be distracted by
+            the readable content of a page when looking at its layout. The point
+            of using Lorem Ipsum is that it has a more-or-less normal
+            distribution of letters, as opposed to using 'Content here, content
+            here', making it look like readable English.
+          </p>
+          <p>
+            Many desktop publishing packages and web page editors now use Lorem
+            Ipsum as their default model text, and a search for 'lorem ipsum'
+            will uncover many web sites still in their infancy. Various versions
+            have evolved over the years, sometimes by accident, sometimes on
+            purpose (injected humour and the like).
+          </p>
+        </div>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FNavigation%2Fnavigation.html%23L20-L121&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/Docs/Rating/rating.html
+++ b/Docs/Rating/rating.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rating</title>
+    <link rel="icon" href="../../hero-icon.svg" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
@@ -13,56 +14,193 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="../default.css" />
-    <link rel="stylesheet" href="rating.css" />
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h2>Rating</h2>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent z-index-2"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
+        </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
 
-      <h3>5 star</h3>
-      <div class="row-container bright-yellow-color">
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-      </div>
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
 
-      <h3>4 star</h3>
-      <div class="row-container bright-blue-color">
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-      </div>
+        <li class="navigation-link-item component-list-button">
+          <button
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
+          >
+            <div class="material-icons-outlined">menu</div>
+          </button>
+        </li>
+      </ul>
+    </nav>
 
-      <h3>3 star</h3>
-      <div class="row-container bright-red-color">
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-      </div>
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
 
-      <h3>2 star</h3>
-      <div class="row-container bright-green-color">
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-      </div>
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
+            </li>
+          </a>
 
-      <h3>1 star</h3>
-      <div class="row-container">
-        <div class="material-icons-outlined md-36">star_rate</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
-        <div class="material-icons-outlined md-36">star_outline</div>
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>Rating</h1>
+        <p>Rating can serve as a feedback for a product or service.</p>
+
+        <h3>5 star</h3>
+        <div class="black-color">
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+        </div>
+
+        <h3>4 star</h3>
+        <div class="bright-blue-color">
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+        </div>
+
+        <h3>3 star</h3>
+        <div class="bright-red-color">
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+        </div>
+
+        <h3>2 star</h3>
+        <div class="bright-green-color">
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+        </div>
+
+        <h3>1 star</h3>
+        <div class="bright-yellow-color">
+          <div class="material-icons-outlined md-36">star_rate</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+          <div class="material-icons-outlined md-36">star_outline</div>
+        </div>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FRating%2Frating.html%23L20-L67&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/Docs/Snackbar/snackbar.html
+++ b/Docs/Snackbar/snackbar.html
@@ -199,7 +199,7 @@
 
         <h2>Code Snippet</h2>
         <section class="code-container">
-          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FRating%2Frating.html%23L20-L67&style=github&showBorder=on&showCopy=on"></script>
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FSnackbar%2Fsnackbar.html%23L20-L55&style=github&showBorder=on&showCopy=on"></script>
         </section>
       </div>
     </div>

--- a/Docs/Snackbar/snackbar.html
+++ b/Docs/Snackbar/snackbar.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Snackbar</title>
+    <link rel="icon" href="../../hero-icon.svg" />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
@@ -13,44 +14,193 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="../default.css" />
-    <link rel="stylesheet" href="snackbar.css" />
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h3>Snackbar</h3>
-      <div class="snackbar">
-        <div class="snackbar-container white-color dark-gray-bg">
-          <div class="snackbar-text">Can't send photo. Retry in 5 seconds.</div>
-          <div class="snackbar-action dark-purple-color">RETRY</div>
-          <div class="material-icons-outlined close-snackbar-icon">cancel</div>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent z-index-2"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
         </div>
-      </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
 
-      <div class="snackbar">
-        <div class="snackbar-container white-color dark-blue-bg">
-          <div>Message Sent Successfully</div>
-          <div class="snackbar-action white-color">UNDO</div>
-          <div class="material-icons-outlined close-snackbar-icon">cancel</div>
-        </div>
-      </div>
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
 
-      <div class="snackbar">
-        <div class="snackbar-container white-color bright-red-bg">
-          <div class="material-icons-outlined">warning_amber</div>
-          <div class="snackbar-text">Network Error</div>
-          <div class="snackbar-action white-color">RETRY</div>
-          <div class="material-icons-outlined close-snackbar-icon">close</div>
-        </div>
-      </div>
+        <li class="navigation-link-item component-list-button">
+          <button
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
+          >
+            <div class="material-icons-outlined">menu</div>
+          </button>
+        </li>
+      </ul>
+    </nav>
 
-      <div class="snackbar">
-        <div class="snackbar-container white-color bright-purple-bg">
-          <div class="material-icons-outlined">info</div>
-          <div class="snackbar-text">Order Successful !!</div>
-          <div class="display-none">INFO</div>
-          <div class="material-icons-outlined close-snackbar-icon">close</div>
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
+
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
+            </li>
+          </a>
+
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>Snackbar</h1>
+        <p>
+          A snackbar is used to provide feedback to a user action, usually
+          displayed at one of the corners of the screen. Based on the following
+          snackbar samples, several varations with different colors, icons and
+          textual content can be easily created.
+        </p>
+
+        <div class="snackbar">
+          <div class="snackbar-container white-color dark-gray-bg">
+            <div class="snackbar-text">
+              Can't send photo. Retry in 5 seconds.
+            </div>
+            <div class="snackbar-action dark-purple-color">RETRY</div>
+            <div class="material-icons-outlined close-snackbar-icon">
+              cancel
+            </div>
+          </div>
         </div>
+
+        <div class="snackbar">
+          <div class="snackbar-container white-color dark-blue-bg">
+            <div>Message Sent Successfully</div>
+            <div class="snackbar-action white-color">UNDO</div>
+            <div class="material-icons-outlined close-snackbar-icon">
+              cancel
+            </div>
+          </div>
+        </div>
+
+        <div class="snackbar">
+          <div class="snackbar-container white-color bright-red-bg">
+            <div class="material-icons-outlined">warning_amber</div>
+            <div class="snackbar-text">Network Error</div>
+            <div class="snackbar-action white-color">RETRY</div>
+            <div class="material-icons-outlined close-snackbar-icon">close</div>
+          </div>
+        </div>
+
+        <div class="snackbar">
+          <div class="snackbar-container white-color bright-purple-bg">
+            <div class="material-icons-outlined">info</div>
+            <div class="snackbar-text">Order Successful !!</div>
+            <div class="display-none">INFO</div>
+            <div class="material-icons-outlined close-snackbar-icon">close</div>
+          </div>
+        </div>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FRating%2Frating.html%23L20-L67&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/Docs/Text-Utilities/text.html
+++ b/Docs/Text-Utilities/text.html
@@ -4,38 +4,183 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Text Utilities</title>
-    <link rel="stylesheet" href="text.css" />
-    <link rel="stylesheet" href="../default.css" />
+    <title>Text-Utilities</title>
+    <link rel="icon" href="../../hero-icon.svg" />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../../nyce.css" />
+    <link rel="stylesheet" href="../../style.css" />
+    <link rel="stylesheet" href="avatar.css" />
+    <script src="../../app.js" defer></script>
   </head>
   <body>
-    <div class="column-container">
-      <h1>Text Utilities</h1>
+    <nav
+      class="navigation fixed-position black-bg white-color navigation-shadow width-100-percent"
+    >
+      <a href="../../index.html" class="home-page-link">
+        <div class="navigation-title-container white-color">
+          <div class="material-icons-outlined">widgets</div>
+          <h1>Nyce UI</h1>
+        </div>
+      </a>
+      <ul class="navigation-links-container">
+        <li class="navigation-link-item desktop-link-item">
+          <div class="material-icons-outlined">file_download</div>
+          <a href="www.google.com" target="_blank">
+            <h4 class="pillbox-button white-bg-black-color">GET Nyce</h4>
+          </a>
+        </li>
 
-      <h2 class="bright-red-color">Headings</h2>
+        <li class="navigation-link-item">
+          <a href="../Avatar/avatar.html">
+            <div class="button pillbox-button white-bg black-color">
+              <h4>Docs</h4>
+            </div>
+          </a>
+        </li>
 
-      <h1>Some H1 text</h1>
-      <h2>Some H2 text</h2>
-      <h3>Some H3 text</h3>
-      <h4>Some H4 text</h4>
-      <h5>Some H5 text</h5>
-      <h6>Some H6 text</h6>
+        <li class="navigation-link-item component-list-button">
+          <button
+            class="button pillbox-button white-bg black-color mobile-link-item component-list-toggle absolute-position"
+          >
+            <div class="material-icons-outlined">menu</div>
+          </button>
+        </li>
+      </ul>
+    </nav>
 
-      <h2 class="bright-red-color">Small text</h2>
-      <p class="small-text">
-        This is some small text, small as in size not in length.
-      </p>
+    <div class="page-content-container">
+      <aside class="component-list-container fixed-position z-index-2">
+        <ul class="default-list">
+          <a href="../Avatar/avatar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Avatar
+            </li>
+          </a>
 
-      <h2 class="bright-red-color">Gray text</h2>
-      <p class="gray-text">This is some gray text</p>
+          <a href="../Alert/alert.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Alert
+            </li>
+          </a>
 
-      <h2 class="bright-red-color">Centered text</h2>
-      <div class="centered-text-container">
-        Typography is the art and technique of arranging type to make written
-        language legible, readable and appealing when displayed. The arrangement
-        of type involves selecting typefaces, point sizes, line lengths,
-        line-spacing (leading), and letter-spacing (tracking), as well as
-        adjusting the space between pairs of letters.
+          <a href="../Badge/badge.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Badge
+            </li>
+          </a>
+
+          <a href="../Button/button.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Button
+            </li>
+          </a>
+
+          <a href="../Card/card.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Card
+            </li>
+          </a>
+
+          <a href="../Image/image.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Image
+            </li>
+          </a>
+
+          <a href="../Input/input.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Input
+            </li>
+          </a>
+
+          <a href="../Text-Utilities/text.html">
+            <li
+              class="component-list-item selected-list-item list-item black-bg white-color"
+            >
+              Text Utilities
+            </li>
+          </a>
+
+          <a href="../List/list.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Lists
+            </li>
+          </a>
+
+          <a href="../Navigation/navigation.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Navigation
+            </li>
+          </a>
+
+          <a href="../Modal/modal.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Modal
+            </li>
+          </a>
+
+          <a href="../Rating/rating.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Rating
+            </li>
+          </a>
+
+          <a href="../Snackbar/snackbar.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Snackbar
+            </li>
+          </a>
+
+          <a href="../Grid/grid.html">
+            <li class="component-list-item list-item black-bg white-color">
+              Grid
+            </li>
+          </a>
+        </ul>
+      </aside>
+
+      <div class="column-container component-details-container">
+        <h1>Text Utilities</h1>
+
+        <h2 class="bright-red-color">Headings</h2>
+
+        <h1>Some H1 text</h1>
+        <h2>Some H2 text</h2>
+        <h3>Some H3 text</h3>
+        <h4>Some H4 text</h4>
+        <h5>Some H5 text</h5>
+        <h6>Some H6 text</h6>
+
+        <h2 class="bright-red-color">Small text</h2>
+        <p class="small-text">
+          This is some small text, small as in size not in length.
+        </p>
+
+        <h2 class="bright-red-color">Gray text</h2>
+        <p class="gray-text">This is some gray text</p>
+
+        <h2 class="bright-red-color">Centered text</h2>
+        <article class="centered-text-container">
+          Typography is the art and technique of arranging type to make written
+          language legible, readable and appealing when displayed. The
+          arrangement of type involves selecting typefaces, point sizes, line
+          lengths, line-spacing (leading), and letter-spacing (tracking), as
+          well as adjusting the space between pairs of letters.
+        </article>
+
+        <br />
+
+        <h2>Code Snippet</h2>
+        <section class="code-container">
+          <script src="https://emgithub.com/embed.js?target=https%3A%2F%2Fgithub.com%2Fddivyansh18%2FNyce-UI%2Fblob%2Fdev%2FComponents%2FText-Utilities%2Ftext.html%23L12-L40&style=github&showBorder=on&showCopy=on"></script>
+        </section>
       </div>
     </div>
   </body>

--- a/style.css
+++ b/style.css
@@ -79,6 +79,14 @@
   align-items: center;
 }
 
+.fixed-navigation-component {
+  width: 30rem;
+}
+
+.fixed-navigation-text-padding {
+  padding-top: 3rem;
+}
+
 /* Common Documentation Page Classes */
 .component-list-item {
   width: 100%;


### PR DESCRIPTION
- Added docs for P1 components :
  - Text Utilities
    - headings
    - small text
   - gray text
   - center text
 - Lists
   - Spaced (normal lists)
   - Stacked (Notification Page)
 - Navigation
    - Desktop (Simple)
  - Modal
  - Rating (for eCommerce)
  - Snackbar
  - Simplified Grid
    - grid-2: two items in a grid
    - grid-3: three items

- The documentation HTML part was already approved in previous individual component PRs, and is reused as it is here.

- Most of the code across pages is same, only minor differences like component description, code etc are changed.